### PR TITLE
refactor: Improves SQL lock insertion query

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ The integration test module doesn't run by default. To run you need to add the p
 ### TODO list
 
 - document database schema or provide a liquibase patch
+- builder pattern to help instantiation


### PR DESCRIPTION
Changes the lock insertion query to not rely on exceptions. Adds a cache for already inserted ids. The implementation is designed to have known ids, so this should not grow much.

Close #3 